### PR TITLE
Fix invalid const variables for Godot 4 RC

### DIFF
--- a/clouds.gdshader
+++ b/clouds.gdshader
@@ -181,8 +181,8 @@ vec4 march(vec3 pos,  vec3 end, vec3 dir, int depth) {
 	vec3 atmosphere_ground = atmosphere(normalize(vec3(1.0, -1.0, 0.0)));
 	
 	const float weather_scale = 0.00006;
-	const float time = TIME * 0.003 * _time_scale + 0.005*_time_offset;
-	const vec2 weather_pos = vec2(time * 0.9, time);
+	float time = TIME * 0.003 * _time_scale + 0.005*_time_offset;
+	vec2 weather_pos = vec2(time * 0.9, time);
 	
 	for (int i = 0; i < depth; i++) {
 		p += dir * ss;


### PR DESCRIPTION
This change is required because of https://github.com/godotengine/godot/pull/72494 (merged into Godot 4 RC 1), which prevents the use of non-const variables when initializing new const variables.