### PR TITLE
feat: add wind-direction to alter "movement" of clouds

### DIFF
--- a/clouds.gdshader
+++ b/clouds.gdshader
@@ -140,10 +140,10 @@ float intersectSphere(vec3 pos, vec3 dir,float r) {
 // Returns density at a given point
 // Heavily based on method from Schneider
 float density(vec3 pip, vec3 weather, float mip) {
-	float time = TIME * wind_speed;
+	float time = TIME;
 	vec3 p = pip;
 	float height_fraction = GetHeightFractionForPoint(length(p));
-	p.xz += time * 20.0 * normalize(wind_direction) * 0.6;
+	p.xz += time * 20.0 * normalize(wind_direction) * wind_speed * 0.6;
 	vec4 n = textureLod(perlworlnoise, p.xyz*0.00008, mip-2.0);
 	float fbm = n.g*0.625+n.b*0.25+n.a*0.125;
 	float g = densityHeightGradient(height_fraction, weather.r);
@@ -181,8 +181,8 @@ vec4 march(vec3 pos,  vec3 end, vec3 dir, int depth) {
 	vec3 atmosphere_ground = atmosphere(normalize(vec3(1.0, -1.0, 0.0)));
 	
 	const float weather_scale = 0.00006;
-	float time = TIME * 0.001 * wind_speed + 0.005 * _time_offset;
-	vec2 weather_pos = time * normalize(wind_direction);
+	float time = TIME * 0.001 + 0.005 * _time_offset;
+	vec2 weather_pos = time * normalize(wind_direction) * wind_speed;
 	
 	for (int i = 0; i < depth; i++) {
 		p += dir * ss;

--- a/clouds.gdshader
+++ b/clouds.gdshader
@@ -151,6 +151,8 @@ float density(vec3 pip, vec3 weather, float mip) {
 	float weather_coverage = cloud_coverage*weather.b;
 	base_cloud = remap(base_cloud*g, 1.0-(weather_coverage), 1.0, 0.0, 1.0);
 	base_cloud *= weather_coverage;
+	p.xz -= time * normalize(wind_direction) * 40.;
+	p.y -= time * 40.;
 	vec3 hn = textureLod(worlnoise, p*0.001, mip).rgb;
 	float hfbm = hn.r*0.625+hn.g*0.25+hn.b*0.125;
 	hfbm = mix(hfbm, 1.0-hfbm, clamp(height_fraction*4.0, 0.0, 1.0));

--- a/clouds.gdshader
+++ b/clouds.gdshader
@@ -7,6 +7,7 @@ uniform sampler3D worlnoise : filter_linear_mipmap, repeat_enable;
 uniform sampler3D perlworlnoise : filter_linear_mipmap, repeat_enable;
 uniform sampler2D weathermap : filter_linear_mipmap, repeat_enable;
 
+uniform vec2 wind_direction = vec2(1, 0);
 uniform float _density : hint_range(0.01, 0.2) = 0.05;
 uniform float cloud_coverage :hint_range(0.1, 1.0) = 0.25;
 uniform float _time_scale :hint_range(0.0, 20.0) = 1.0;
@@ -139,10 +140,10 @@ float intersectSphere(vec3 pos, vec3 dir,float r) {
 // Returns density at a given point
 // Heavily based on method from Schneider
 float density(vec3 pip, vec3 weather, float mip) {
-	float time = TIME;
+	float time = TIME * _time_scale;
 	vec3 p = pip;
-	p.x += time * 10.0 * _time_scale + _time_offset;
 	float height_fraction = GetHeightFractionForPoint(length(p));
+	p.xz += time * 20.0 * normalize(wind_direction) * 0.6;
 	vec4 n = textureLod(perlworlnoise, p.xyz*0.00008, mip-2.0);
 	float fbm = n.g*0.625+n.b*0.25+n.a*0.125;
 	float g = densityHeightGradient(height_fraction, weather.r);
@@ -150,7 +151,6 @@ float density(vec3 pip, vec3 weather, float mip) {
 	float weather_coverage = cloud_coverage*weather.b;
 	base_cloud = remap(base_cloud*g, 1.0-(weather_coverage), 1.0, 0.0, 1.0);
 	base_cloud *= weather_coverage;
-	p.xy -= time * 40.0;
 	vec3 hn = textureLod(worlnoise, p*0.001, mip).rgb;
 	float hfbm = hn.r*0.625+hn.g*0.25+hn.b*0.125;
 	hfbm = mix(hfbm, 1.0-hfbm, clamp(height_fraction*4.0, 0.0, 1.0));
@@ -181,8 +181,8 @@ vec4 march(vec3 pos,  vec3 end, vec3 dir, int depth) {
 	vec3 atmosphere_ground = atmosphere(normalize(vec3(1.0, -1.0, 0.0)));
 	
 	const float weather_scale = 0.00006;
-	float time = TIME * 0.003 * _time_scale + 0.005*_time_offset;
-	vec2 weather_pos = vec2(time * 0.9, time);
+	float time = TIME * 0.001 * _time_scale + 0.005 * _time_offset;
+	vec2 weather_pos = time * normalize(wind_direction);
 	
 	for (int i = 0; i < depth; i++) {
 		p += dir * ss;

--- a/clouds.gdshader
+++ b/clouds.gdshader
@@ -8,9 +8,9 @@ uniform sampler3D perlworlnoise : filter_linear_mipmap, repeat_enable;
 uniform sampler2D weathermap : filter_linear_mipmap, repeat_enable;
 
 uniform vec2 wind_direction = vec2(1, 0);
+uniform float wind_speed :hint_range(0.0, 20.0) = 1.0;
 uniform float _density : hint_range(0.01, 0.2) = 0.05;
 uniform float cloud_coverage :hint_range(0.1, 1.0) = 0.25;
-uniform float _time_scale :hint_range(0.0, 20.0) = 1.0;
 uniform float _time_offset : hint_range(0.0, 1000.0, 0.5) = 0.0;
 
 // Approximately earth sizes
@@ -140,7 +140,7 @@ float intersectSphere(vec3 pos, vec3 dir,float r) {
 // Returns density at a given point
 // Heavily based on method from Schneider
 float density(vec3 pip, vec3 weather, float mip) {
-	float time = TIME * _time_scale;
+	float time = TIME * wind_speed;
 	vec3 p = pip;
 	float height_fraction = GetHeightFractionForPoint(length(p));
 	p.xz += time * 20.0 * normalize(wind_direction) * 0.6;
@@ -181,7 +181,7 @@ vec4 march(vec3 pos,  vec3 end, vec3 dir, int depth) {
 	vec3 atmosphere_ground = atmosphere(normalize(vec3(1.0, -1.0, 0.0)));
 	
 	const float weather_scale = 0.00006;
-	float time = TIME * 0.001 * _time_scale + 0.005 * _time_offset;
+	float time = TIME * 0.001 * wind_speed + 0.005 * _time_offset;
 	vec2 weather_pos = time * normalize(wind_direction);
 	
 	for (int i = 0; i < depth; i++) {


### PR DESCRIPTION
Not sure if this was ever an intended use-case, but i think this could be a useful feature for other people as well. 

Clouds move in the direction of `wind-direction` vector2. `_time_scale` has been renamed to `wind_speed` and alters how fast clouds fly. Some additional changes and restructuring in the calculations were necessary for sensible wind-speed scales and appropriate texture reads.